### PR TITLE
Adds int4 Quantization Support

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -56,6 +56,6 @@ jobs:
 
       # Upload the results to GitHub's code scanning dashboard.
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@181d5eefc20863364f96762470ba6f862bdef56b # v3.29.2
+        uses: github/codeql-action/upload-sarif@ff0a06e83cb2de871e5a09832bc6a81e7276941f # v3.28.18
         with:
           sarif_file: results.sarif

--- a/keras/api/_tf_keras/keras/ops/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/__init__.py
@@ -149,7 +149,6 @@ from keras.src.ops.numpy import bitwise_right_shift as bitwise_right_shift
 from keras.src.ops.numpy import bitwise_xor as bitwise_xor
 from keras.src.ops.numpy import blackman as blackman
 from keras.src.ops.numpy import broadcast_to as broadcast_to
-from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
 from keras.src.ops.numpy import concatenate as concatenate
@@ -164,7 +163,6 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
-from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/api/_tf_keras/keras/ops/numpy/__init__.py
+++ b/keras/api/_tf_keras/keras/ops/numpy/__init__.py
@@ -38,7 +38,6 @@ from keras.src.ops.numpy import bitwise_right_shift as bitwise_right_shift
 from keras.src.ops.numpy import bitwise_xor as bitwise_xor
 from keras.src.ops.numpy import blackman as blackman
 from keras.src.ops.numpy import broadcast_to as broadcast_to
-from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
 from keras.src.ops.numpy import concatenate as concatenate
@@ -53,7 +52,6 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
-from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/api/_tf_keras/keras/quantizers/__init__.py
+++ b/keras/api/_tf_keras/keras/quantizers/__init__.py
@@ -19,6 +19,8 @@ from keras.src.quantizers.quantizers import (
 from keras.src.quantizers.quantizers import (
     fake_quant_with_min_max_vars as fake_quant_with_min_max_vars,
 )
+from keras.src.quantizers.quantizers import pack_int4 as pack_int4
 from keras.src.quantizers.quantizers import (
     quantize_and_dequantize as quantize_and_dequantize,
 )
+from keras.src.quantizers.quantizers import unpack_int4 as unpack_int4

--- a/keras/api/ops/__init__.py
+++ b/keras/api/ops/__init__.py
@@ -149,7 +149,6 @@ from keras.src.ops.numpy import bitwise_right_shift as bitwise_right_shift
 from keras.src.ops.numpy import bitwise_xor as bitwise_xor
 from keras.src.ops.numpy import blackman as blackman
 from keras.src.ops.numpy import broadcast_to as broadcast_to
-from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
 from keras.src.ops.numpy import concatenate as concatenate
@@ -164,7 +163,6 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
-from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/api/ops/numpy/__init__.py
+++ b/keras/api/ops/numpy/__init__.py
@@ -38,7 +38,6 @@ from keras.src.ops.numpy import bitwise_right_shift as bitwise_right_shift
 from keras.src.ops.numpy import bitwise_xor as bitwise_xor
 from keras.src.ops.numpy import blackman as blackman
 from keras.src.ops.numpy import broadcast_to as broadcast_to
-from keras.src.ops.numpy import cbrt as cbrt
 from keras.src.ops.numpy import ceil as ceil
 from keras.src.ops.numpy import clip as clip
 from keras.src.ops.numpy import concatenate as concatenate
@@ -53,7 +52,6 @@ from keras.src.ops.numpy import count_nonzero as count_nonzero
 from keras.src.ops.numpy import cross as cross
 from keras.src.ops.numpy import cumprod as cumprod
 from keras.src.ops.numpy import cumsum as cumsum
-from keras.src.ops.numpy import deg2rad as deg2rad
 from keras.src.ops.numpy import diag as diag
 from keras.src.ops.numpy import diagflat as diagflat
 from keras.src.ops.numpy import diagonal as diagonal

--- a/keras/api/quantizers/__init__.py
+++ b/keras/api/quantizers/__init__.py
@@ -19,6 +19,8 @@ from keras.src.quantizers.quantizers import (
 from keras.src.quantizers.quantizers import (
     fake_quant_with_min_max_vars as fake_quant_with_min_max_vars,
 )
+from keras.src.quantizers.quantizers import pack_int4 as pack_int4
 from keras.src.quantizers.quantizers import (
     quantize_and_dequantize as quantize_and_dequantize,
 )
+from keras.src.quantizers.quantizers import unpack_int4 as unpack_int4

--- a/keras/src/backend/jax/numpy.py
+++ b/keras/src/backend/jax/numpy.py
@@ -499,11 +499,6 @@ def broadcast_to(x, shape):
     return jnp.broadcast_to(x, shape)
 
 
-def cbrt(x):
-    x = convert_to_tensor(x)
-    return jnp.cbrt(x)
-
-
 @sparse.elementwise_unary(linear=False)
 def ceil(x):
     x = convert_to_tensor(x)
@@ -601,11 +596,6 @@ def cumprod(x, axis=None, dtype=None):
 def cumsum(x, axis=None, dtype=None):
     x = convert_to_tensor(x)
     return jnp.cumsum(x, axis=axis, dtype=dtype)
-
-
-def deg2rad(x):
-    x = convert_to_tensor(x)
-    return jnp.deg2rad(x)
 
 
 def diag(x, k=0):

--- a/keras/src/backend/numpy/numpy.py
+++ b/keras/src/backend/numpy/numpy.py
@@ -414,18 +414,6 @@ def broadcast_to(x, shape):
     return np.broadcast_to(x, shape)
 
 
-def cbrt(x):
-    x = convert_to_tensor(x)
-
-    dtype = standardize_dtype(x.dtype)
-    if dtype in ["bool", "int8", "int16", "int32", "uint8", "uint16", "uint32"]:
-        dtype = config.floatx()
-    elif dtype == "int64":
-        dtype = "float64"
-
-    return np.cbrt(x).astype(dtype)
-
-
 def ceil(x):
     x = convert_to_tensor(x)
     if standardize_dtype(x.dtype) == "int64":
@@ -525,19 +513,6 @@ def cumsum(x, axis=None, dtype=None):
     if dtype == "bool":
         dtype = "int32"
     return np.cumsum(x, axis=axis, dtype=dtype)
-
-
-def deg2rad(x):
-    x = convert_to_tensor(x)
-
-    if x.dtype in ["int64", "float64"]:
-        dtype = "float64"
-    elif x.dtype in ["bfloat16", "float16"]:
-        dtype = x.dtype
-    else:
-        dtype = config.floatx()
-
-    return np.deg2rad(x).astype(dtype)
 
 
 def diag(x, k=0):

--- a/keras/src/backend/openvino/excluded_concrete_tests.txt
+++ b/keras/src/backend/openvino/excluded_concrete_tests.txt
@@ -14,7 +14,6 @@ NumpyDtypeTest::test_hamming
 NumpyDtypeTest::test_hanning
 NumpyDtypeTest::test_kaiser
 NumpyDtypeTest::test_bitwise
-NumpyDtypeTest::test_cbrt
 NumpyDtypeTest::test_ceil
 NumpyDtypeTest::test_concatenate
 NumpyDtypeTest::test_corrcoef
@@ -22,7 +21,6 @@ NumpyDtypeTest::test_correlate
 NumpyDtypeTest::test_cross
 NumpyDtypeTest::test_cumprod
 NumpyDtypeTest::test_cumsum_bool
-NumpyDtypeTest::test_deg2rad
 NumpyDtypeTest::test_diag
 NumpyDtypeTest::test_digitize
 NumpyDtypeTest::test_einsum
@@ -82,12 +80,10 @@ NumpyOneInputOpsCorrectnessTest::test_hamming
 NumpyOneInputOpsCorrectnessTest::test_hanning
 NumpyOneInputOpsCorrectnessTest::test_kaiser
 NumpyOneInputOpsCorrectnessTest::test_bitwise_invert
-NumpyOneInputOpsCorrectnessTest::test_cbrt
 NumpyOneInputOpsCorrectnessTest::test_conj
 NumpyOneInputOpsCorrectnessTest::test_corrcoef
 NumpyOneInputOpsCorrectnessTest::test_correlate
 NumpyOneInputOpsCorrectnessTest::test_cumprod
-NumpyOneInputOpsCorrectnessTest::test_deg2rad
 NumpyOneInputOpsCorrectnessTest::test_diag
 NumpyOneInputOpsCorrectnessTest::test_diagonal
 NumpyOneInputOpsCorrectnessTest::test_exp2
@@ -155,15 +151,11 @@ NumpyTwoInputOpsCorrectnessTest::test_vdot
 NumpyOneInputOpsDynamicShapeTest::test_angle
 NumpyOneInputOpsDynamicShapeTest::test_bartlett
 NumpyOneInputOpsDynamicShapeTest::test_blackman
-NumpyOneInputOpsDynamicShapeTest::test_cbrt
 NumpyOneInputOpsDynamicShapeTest::test_corrcoef
-NumpyOneInputOpsDynamicShapeTest::test_deg2rad
 NumpyOneInputOpsDynamicShapeTest::test_hamming
 NumpyOneInputOpsDynamicShapeTest::test_hanning
 NumpyOneInputOpsDynamicShapeTest::test_kaiser
 NumpyOneInputOpsStaticShapeTest::test_angle
-NumpyOneInputOpsStaticShapeTest::test_cbrt
-NumpyOneInputOpsStaticShapeTest::test_deg2rad
 CoreOpsBehaviorTests::test_associative_scan_invalid_arguments
 CoreOpsBehaviorTests::test_scan_invalid_arguments
 CoreOpsCallsTests::test_associative_scan_basic_call

--- a/keras/src/backend/openvino/numpy.py
+++ b/keras/src/backend/openvino/numpy.py
@@ -545,10 +545,6 @@ def broadcast_to(x, shape):
     return OpenVINOKerasTensor(ov_opset.broadcast(x, target_shape).output(0))
 
 
-def cbrt(x):
-    raise NotImplementedError("`cbrt` is not supported with openvino backend")
-
-
 def ceil(x):
     x = get_ov_output(x)
     return OpenVINOKerasTensor(ov_opset.ceil(x).output(0))
@@ -644,12 +640,6 @@ def cumsum(x, axis=None, dtype=None):
         axis = 0
     axis = ov_opset.constant(axis, Type.i32).output(0)
     return OpenVINOKerasTensor(ov_opset.cumsum(x, axis).output(0))
-
-
-def deg2rad(x):
-    raise NotImplementedError(
-        "`deg2rad` is not supported with openvino backend"
-    )
 
 
 def diag(x, k=0):
@@ -1177,9 +1167,9 @@ def nan_to_num(x, nan=0.0, posinf=None, neginf=None):
 
 def ndim(x):
     x = get_ov_output(x)
-    shape_tensor = ov_opset.shape_of(x, Type.i64).output(0)
-    rank_tensor = ov_opset.shape_of(shape_tensor, Type.i64).output(0)
-    return OpenVINOKerasTensor(rank_tensor)
+    x_shape = ov_opset.shape_of(x).output(0)
+    x_dim = ov_opset.shape_of(x_shape, "i64")
+    return x_dim
 
 
 def nonzero(x):

--- a/keras/src/backend/tensorflow/numpy.py
+++ b/keras/src/backend/tensorflow/numpy.py
@@ -1089,18 +1089,6 @@ def broadcast_to(x, shape):
     return tf.broadcast_to(x, shape)
 
 
-def cbrt(x):
-    x = convert_to_tensor(x)
-
-    dtype = standardize_dtype(x.dtype)
-    if dtype == "int64":
-        x = tf.cast(x, "float64")
-    elif dtype not in ["bfloat16", "float16", "float64"]:
-        x = tf.cast(x, config.floatx())
-
-    return tf.sign(x) * tf.pow(tf.abs(x), 1.0 / 3.0)
-
-
 @sparse.elementwise_unary
 def ceil(x):
     x = convert_to_tensor(x)
@@ -1266,28 +1254,6 @@ def cumsum(x, axis=None, dtype=None):
         x = tf.reshape(x, [-1])
         axis = 0
     return tf.math.cumsum(x, axis=axis)
-
-
-def deg2rad(x):
-    x = convert_to_tensor(x)
-
-    dtype = x.dtype
-    if standardize_dtype(dtype) in [
-        "bool",
-        "int8",
-        "int16",
-        "int32",
-        "uint8",
-        "uint16",
-        "uint32",
-    ]:
-        dtype = config.floatx()
-    elif standardize_dtype(dtype) in ["int64"]:
-        dtype = "float64"
-    x = tf.cast(x, dtype)
-
-    pi = tf.constant(math.pi, dtype=dtype)
-    return x * (pi / tf.constant(180.0, dtype=dtype))
 
 
 def diag(x, k=0):

--- a/keras/src/backend/torch/core.py
+++ b/keras/src/backend/torch/core.py
@@ -192,10 +192,10 @@ def convert_to_tensor(x, dtype=None, sparse=None, ragged=None):
     if ragged:
         raise ValueError("`ragged=True` is not supported with torch backend")
     if isinstance(x, Variable):
-        if dtype is None:
-            return x.value
-        x = x.value
-        return x.to(to_torch_dtype(dtype))
+        # TorchDynamo has bugs supporting nn.Parameter type check.
+        # Return it directly instead of pass it to the rest of the logic in the
+        # function.
+        return x.value
     if is_tensor(x):
         device = get_device()
         if x.device != device:

--- a/keras/src/backend/torch/numpy.py
+++ b/keras/src/backend/torch/numpy.py
@@ -540,18 +540,6 @@ def broadcast_to(x, shape):
     return torch.broadcast_to(x, shape)
 
 
-def cbrt(x):
-    x = convert_to_tensor(x)
-
-    dtype = standardize_dtype(x.dtype)
-    if dtype == "bool":
-        x = cast(x, "int32")
-    elif dtype == "int64":
-        x = cast(x, "float64")
-
-    return torch.sign(x) * torch.abs(x) ** (1.0 / 3.0)
-
-
 def ceil(x):
     x = convert_to_tensor(x)
     ori_dtype = standardize_dtype(x.dtype)
@@ -680,15 +668,6 @@ def cumsum(x, axis=None, dtype=None):
             "float16",
         )
     return torch.cumsum(x, dim=axis, dtype=to_torch_dtype(dtype))
-
-
-def deg2rad(x):
-    x = convert_to_tensor(x)
-
-    if standardize_dtype(x.dtype) == "int64":
-        return cast(torch.deg2rad(x), "float64")
-
-    return torch.deg2rad(x)
 
 
 def diag(x, k=0):

--- a/keras/src/backend/torch/rnn.py
+++ b/keras/src/backend/torch/rnn.py
@@ -228,8 +228,6 @@ def rnn(
         elif isinstance(input_length, torch.Tensor):
             if go_backwards:
                 max_len = torch.max(input_length, dim=0)
-                if isinstance(max_len, torch.return_types.max):
-                    max_len = max_len[0]
                 rev_input_length = torch.subtract(max_len - 1, input_length)
 
                 def masking_fn(time):

--- a/keras/src/distribution/distribution_lib.py
+++ b/keras/src/distribution/distribution_lib.py
@@ -297,19 +297,11 @@ class Distribution:
 
     Args:
         device_mesh: A `DeviceMesh` instance.
-        batch_dim_name: Optional string name for the batch dimension.
-            Defaults to None.
-        auto_shard_dataset: Automatically shard the dataset amongst
-            processes in a multi-process setting. Set to `False` if the dataset
-            is already sharded across hosts.  Defaults to `True`.
     """
 
-    def __init__(
-        self, device_mesh, batch_dim_name=None, auto_shard_dataset=True
-    ):
+    def __init__(self, device_mesh, batch_dim_name=None):
         self._device_mesh = device_mesh
         self._batch_dim_name = batch_dim_name
-        self._auto_shard_dataset = auto_shard_dataset
 
     def get_data_layout(self, data_shape):
         """Retrieve the `TensorLayout` for the input data.
@@ -366,28 +358,16 @@ class Distribution:
     def batch_dim_name(self):
         return self._batch_dim_name
 
-    @property
-    def auto_shard_dataset(self):
-        return self._auto_shard_dataset
-
-    @auto_shard_dataset.setter
-    def auto_shard_dataset(self, auto_shard_dataset):
-        self._auto_shard_dataset = auto_shard_dataset
-
     def distribute_dataset(self, dataset):
-        """Create a distributed dataset from the original global dataset.
+        """Create a distributed dataset instance from the original user dataset.
 
         Args:
-            dataset: the original global dataset instance.
+            dataset: the original global dataset instance. Only
+            `tf.data.Dataset` is supported at the moment.
 
         Returns:
-            If `auto_shard_dataset` is `True`, returns a sharded dataset that
-            only produces data for the current local worker/process.  Otherwise,
-            returns the original dataset.
-
-        Raises:
-            ValueError: if auto-sharding is requested in a multi-process
-            setting, but the dataset type is not supported.
+            a sharded `tf.data.Dataset` instance, which will produce data for
+            the current local worker/process.
         """
         raise NotImplementedError()
 
@@ -420,33 +400,31 @@ class DataParallel(Distribution):
     Args:
         device_mesh: Optional `DeviceMesh` instance.
         devices: Optional list of devices.
-        auto_shard_dataset: Automatically shard the dataset amongst
-            processes in a multi-process setting. Set to `False` if the dataset
-            is already sharded across hosts.  Defaults to `True`.
+        auto_shard_dataset: Automatically shard the dataset amongst processes.
+            Defaults to true.
     """
 
     def __init__(self, device_mesh=None, devices=None, auto_shard_dataset=True):
         if device_mesh:
-            self._initialize_with_device_mesh(device_mesh, auto_shard_dataset)
+            self._initialize_with_device_mesh(device_mesh)
         elif devices:
-            self._initialize_mesh_from_devices(devices, auto_shard_dataset)
+            self._initialize_mesh_from_devices(devices)
         else:
-            self._initialize_mesh_from_list_devices(auto_shard_dataset)
+            self._initialize_mesh_from_list_devices()
 
         # Those following attributes might get convert to public methods.
         self._num_process = distribution_lib.num_processes()
         self._process_id = distribution_lib.process_id()
         self._is_multi_process = self._num_process > 1
+        self._auto_shard_dataset = auto_shard_dataset
 
-    def _initialize_with_device_mesh(self, device_mesh, auto_shard_dataset):
+    def _initialize_with_device_mesh(self, device_mesh):
         if not isinstance(device_mesh, DeviceMesh):
             raise ValueError(
                 "Expect `mesh` to be an instance of `DeviceMesh`. "
                 f"Received: mesh={device_mesh} (of type {type(device_mesh)})"
             )
-        super().__init__(
-            device_mesh, device_mesh.axis_names[0], auto_shard_dataset
-        )
+        super().__init__(device_mesh, device_mesh.axis_names[0])
         if self.device_mesh.devices.ndim != 1:
             warnings.warn(
                 "Expect the input mesh to be 1D, but received "
@@ -455,27 +433,23 @@ class DataParallel(Distribution):
                 device_mesh.devices.ndim,
             )
 
-    def _initialize_mesh_from_devices(self, devices, auto_shard_dataset):
+    def _initialize_mesh_from_devices(self, devices):
         devices = np.array(devices)
         device_mesh = DeviceMesh(
             shape=devices.shape,
             axis_names=[DEFAULT_BATCH_DIM_NAME],
             devices=devices,
         )
-        super().__init__(
-            device_mesh, DEFAULT_BATCH_DIM_NAME, auto_shard_dataset
-        )
+        super().__init__(device_mesh, DEFAULT_BATCH_DIM_NAME)
 
-    def _initialize_mesh_from_list_devices(self, auto_shard_dataset):
+    def _initialize_mesh_from_list_devices(self):
         devices = np.array(list_devices())
         device_mesh = DeviceMesh(
             shape=devices.shape,
             axis_names=[DEFAULT_BATCH_DIM_NAME],
             devices=devices,
         )
-        super().__init__(
-            device_mesh, DEFAULT_BATCH_DIM_NAME, auto_shard_dataset
-        )
+        super().__init__(device_mesh, DEFAULT_BATCH_DIM_NAME)
 
     def get_data_layout(self, data_shape):
         data_shard_spec = [None] * len(data_shape)
@@ -495,21 +469,19 @@ class DataParallel(Distribution):
         return None
 
     def distribute_dataset(self, dataset):
-        if not self._is_multi_process or not self.auto_shard_dataset:
-            return dataset
-
-        # Try to distribute a global tf.data.Dataset.
-        from keras.src.utils.module_utils import tensorflow as tf
-
-        if not tf.available or not isinstance(dataset, tf.data.Dataset):
-            raise ValueError(
-                "Only `tf.data.Dataset` is supported for auto-sharding, "
-                f"got {type(dataset)}"
-            )
-
         from tensorflow.python.data.experimental.ops import (
             distribute as tf_data_distribute,
         )
+
+        from keras.src.utils.module_utils import tensorflow as tf
+
+        if not isinstance(dataset, tf.data.Dataset):
+            raise ValueError(
+                "Only `tf.data.Dataset` is supported for "
+                f"sharding, got {type(dataset)}"
+            )
+        if not self._is_multi_process or not self._auto_shard_dataset:
+            return dataset
 
         batch_size = tf_data_distribute.compute_batch_size(dataset)
         if batch_size.numpy() < 0:
@@ -615,19 +587,9 @@ class ModelParallel(Distribution):
             (of the `layout_map` object)
             that will be used to distribute data. If unspecified, the
             first axis from the device mesh will be used.
-        auto_shard_dataset: Automatically shard the dataset amongst
-            processes in a multi-process setting. Set to `False` if the dataset
-            is already sharded across hosts.  Defaults to `True`.
     """
 
-    def __init__(
-        self,
-        *,
-        layout_map=None,
-        batch_dim_name=None,
-        auto_shard_dataset=True,
-        **kwargs,
-    ):
+    def __init__(self, *, layout_map=None, batch_dim_name=None, **kwargs):
         kwargs.pop("device_mesh", None)
         if layout_map is None:
             raise ValueError("You must specify a layout_map argument.")
@@ -637,9 +599,9 @@ class ModelParallel(Distribution):
                 f"Received: layout_map={layout_map}"
             )
         device_mesh = layout_map.device_mesh
-        batch_dim_name = batch_dim_name or device_mesh.axis_names[0]
-        super().__init__(device_mesh, batch_dim_name, auto_shard_dataset)
+        super().__init__(device_mesh)
         self._layout_map = layout_map
+        self._batch_dim_name = batch_dim_name or self.device_mesh.axis_names[0]
 
         # Those following attributes might get convert to public methods.
         self._num_process = distribution_lib.num_processes()
@@ -666,21 +628,19 @@ class ModelParallel(Distribution):
         return self._layout_map[path]
 
     def distribute_dataset(self, dataset):
-        if not self._is_multi_process or not self.auto_shard_dataset:
-            return dataset
-
-        # Try to distribute a global tf.data.Dataset.
-        from keras.src.utils.module_utils import tensorflow as tf
-
-        if not tf.available or not isinstance(dataset, tf.data.Dataset):
-            raise ValueError(
-                "Only `tf.data.Dataset` is supported for auto-sharding, "
-                f"got {type(dataset)}"
-            )
-
         from tensorflow.python.data.experimental.ops import (
             distribute as tf_data_distribute,
         )
+
+        from keras.src.utils.module_utils import tensorflow as tf
+
+        if not isinstance(dataset, tf.data.Dataset):
+            raise ValueError(
+                "Only `tf.data.Dataset` is supported for "
+                f"sharding, got {type(dataset)}"
+            )
+        if not self._is_multi_process:
+            return dataset
 
         global_batch_size = tf_data_distribute.compute_batch_size(dataset)
         if global_batch_size.numpy() < 0:

--- a/keras/src/dtype_policies/dtype_policy.py
+++ b/keras/src/dtype_policies/dtype_policy.py
@@ -3,7 +3,7 @@ from keras.src import ops
 from keras.src.api_export import keras_export
 from keras.src.backend.common import global_state
 
-QUANTIZATION_MODES = ("int8", "float8")
+QUANTIZATION_MODES = ("int8", "float8", "int4")
 
 
 @keras_export(
@@ -350,7 +350,7 @@ def _get_quantized_dtype_policy_by_str(policy):
             f"Received: policy={policy}"
         )
     mode, source_name = split_name
-    if policy.startswith("int8"):
+    if policy.startswith("int8") or policy.startswith("int4"):
         return QuantizedDTypePolicy(mode, source_name)
     elif policy.startswith("float8"):
         return QuantizedFloat8DTypePolicy(mode, source_name)

--- a/keras/src/export/onnx_test.py
+++ b/keras/src/export/onnx_test.py
@@ -45,28 +45,6 @@ def get_model(type="sequential", input_shape=(10,), layer_list=None):
         return models.Model(inputs=input, outputs=output)
     elif type == "subclass":
         return CustomModel(layer_list)
-    elif type == "lstm":
-        # https://github.com/keras-team/keras/issues/21390
-        inputs = layers.Input((4, 10))
-        x = layers.Bidirectional(
-            layers.LSTM(
-                10,
-                kernel_initializer="he_normal",
-                return_sequences=True,
-                kernel_regularizer=None,
-            ),
-            merge_mode="sum",
-        )(inputs)
-        outputs = layers.Bidirectional(
-            layers.LSTM(
-                10,
-                kernel_initializer="he_normal",
-                return_sequences=True,
-                kernel_regularizer=None,
-            ),
-            merge_mode="concat",
-        )(x)
-        return models.Model(inputs=inputs, outputs=outputs)
 
 
 @pytest.mark.skipif(
@@ -77,24 +55,15 @@ def get_model(type="sequential", input_shape=(10,), layer_list=None):
     ),
 )
 @pytest.mark.skipif(testing.jax_uses_gpu(), reason="Leads to core dumps on CI")
-@pytest.mark.skipif(
-    testing.tensorflow_uses_gpu(), reason="Leads to core dumps on CI"
-)
 class ExportONNXTest(testing.TestCase):
     @parameterized.named_parameters(
-        named_product(
-            model_type=["sequential", "functional", "subclass", "lstm"]
-        )
+        named_product(model_type=["sequential", "functional", "subclass"])
     )
     def test_standard_model_export(self, model_type):
         temp_filepath = os.path.join(self.get_temp_dir(), "exported_model")
         model = get_model(model_type)
         batch_size = 3 if backend.backend() != "torch" else 1
-        if model_type == "lstm":
-            ref_input = np.random.normal(size=(batch_size, 4, 10))
-        else:
-            ref_input = np.random.normal(size=(batch_size, 10))
-        ref_input = ref_input.astype("float32")
+        ref_input = np.random.normal(size=(batch_size, 10)).astype("float32")
         ref_output = model(ref_input)
 
         onnx.export_onnx(model, temp_filepath)

--- a/keras/src/layers/core/dense.py
+++ b/keras/src/layers/core/dense.py
@@ -2,7 +2,6 @@ import ml_dtypes
 
 from keras.src import activations
 from keras.src import constraints
-from keras.src import dtype_policies
 from keras.src import initializers
 from keras.src import ops
 from keras.src import quantizers
@@ -110,9 +109,10 @@ class Dense(Layer):
         kernel_shape = (input_shape[-1], self.units)
         if self.quantization_mode:
             self.quantized_build(kernel_shape, mode=self.quantization_mode)
-        if self.quantization_mode != "int8":
-            # If the layer is quantized to int8, `self._kernel` will be added
-            # in `self._int8_build`. Therefore, we skip it here.
+        if self.quantization_mode not in ("int8", "int4"):
+            # If the layer is quantized to int8 or int4, `self._kernel` will be
+            # added in `self._int8_build` or `_int4_build`. Therefore, we skip
+            # it here.
             self._kernel = self.add_weight(
                 name="kernel",
                 shape=kernel_shape,
@@ -182,9 +182,22 @@ class Dense(Layer):
                 "lora is already enabled. This can only be done once per layer."
             )
         self._tracker.unlock()
+        # Determine the correct input dimension for the LoRA A matrix. When
+        # the layer has been int4-quantized, `self._kernel` stores a *packed*
+        # representation whose first dimension is `ceil(input_dim/2)`. We
+        # saved the true, *unpacked* input dimension in `self._orig_input_dim`
+        # during quantization. Use it if available; otherwise fall back to the
+        # first dimension of `self.kernel`.
+        if self.quantization_mode == "int4" and hasattr(
+            self, "_orig_input_dim"
+        ):
+            input_dim_for_lora = self._orig_input_dim
+        else:
+            input_dim_for_lora = self.kernel.shape[0]
+
         self.lora_kernel_a = self.add_weight(
             name="lora_kernel_a",
-            shape=(self.kernel.shape[0], rank),
+            shape=(input_dim_for_lora, rank),
             initializer=initializers.get(a_initializer),
             regularizer=self.kernel_regularizer,
         )
@@ -211,7 +224,7 @@ class Dense(Layer):
         if self.use_bias:
             target_variables.append(self.bias)
         if self.quantization_mode is not None:
-            if self.quantization_mode == "int8":
+            if self.quantization_mode in ("int8", "int4"):
                 target_variables.append(kernel_scale)
             elif self.quantization_mode == "float8":
                 target_variables.append(self.inputs_scale)
@@ -237,7 +250,7 @@ class Dense(Layer):
         if self.use_bias:
             target_variables.append(self.bias)
         if self.quantization_mode is not None:
-            if self.quantization_mode == "int8":
+            if self.quantization_mode in ("int8", "int4"):
                 target_variables.append(self.kernel_scale)
             elif self.quantization_mode == "float8":
                 target_variables.append(self.inputs_scale)
@@ -315,6 +328,8 @@ class Dense(Layer):
     def quantized_build(self, kernel_shape, mode):
         if mode == "int8":
             self._int8_build(kernel_shape)
+        elif mode == "int4":
+            self._int4_build(kernel_shape)
         elif mode == "float8":
             self._float8_build()
         else:
@@ -336,6 +351,39 @@ class Dense(Layer):
             initializer="ones",
             trainable=False,
         )
+
+    def _int4_build(self, kernel_shape):
+        """Build variables for int4 quantization.
+
+        `kernel_shape` is the *original* float32 kernel shape
+        `(input_dim, units)`. We allocate the stored kernel with rows
+        `ceil(input_dim/2)` because two int4 values are packed into a single
+        int8 byte.
+        """
+        # Per-channel int8 quantizer for the last axis (features).
+        self.inputs_quantizer = quantizers.AbsMaxQuantizer(
+            axis=-1,
+        )
+        input_dim, output_dim = kernel_shape
+        packed_rows = (input_dim + 1) // 2  # ceil for odd dims
+
+        # Kernel is stored *packed*: each int8 byte contains two int4 values.
+        self._kernel = self.add_weight(
+            name="kernel",
+            shape=(packed_rows, output_dim),
+            initializer="zeros",
+            dtype="int8",
+            trainable=False,
+        )
+        # One scale per output unit (per-channel).
+        self.kernel_scale = self.add_weight(
+            name="kernel_scale",
+            shape=(self.units,),
+            initializer="ones",
+            trainable=False,
+        )
+        # Record original input_dim for unpacking at runtime.
+        self._orig_input_dim = input_dim
 
     def _float8_build(self):
         from keras.src.dtype_policies import QuantizedFloat8DTypePolicy
@@ -383,6 +431,16 @@ class Dense(Layer):
     def _int8_call(self, inputs, training=None):
         @ops.custom_gradient
         def matmul_with_inputs_gradient(inputs, kernel, kernel_scale):
+            """Custom gradient function to handle the int8 quantized weights.
+
+            Automatic differentiation will not know how to handle the int8
+            quantized weights. So a custom gradient function is needed to
+            handle the int8 quantized weights.
+
+            The custom gradient function will use the dequantized kernel to
+            compute the gradient.
+            """
+
             def grad_fn(*args, upstream=None):
                 if upstream is None:
                     (upstream,) = args
@@ -409,6 +467,59 @@ class Dense(Layer):
             lora_x = ops.matmul(inputs, self.lora_kernel_a)
             lora_x = ops.matmul(lora_x, self.lora_kernel_b)
             x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
+        if self.bias is not None:
+            x = ops.add(x, self.bias)
+        if self.activation is not None:
+            x = self.activation(x)
+        return x
+
+    def _int4_call(self, inputs, training=None):
+        """Forward pass for int4 quantized Dense layer."""
+
+        @ops.custom_gradient
+        def matmul_with_inputs_gradient(inputs, kernel, kernel_scale):
+            """Custom gradient function for int4 quantized weights.
+
+            Automatic differentiation will not know how to handle the
+            int4 quantized weights. So a custom gradient function is needed
+            to handle the int4 quantized weights.
+
+            The custom gradient function will use the dequantized kernel to
+            compute the gradient.
+            """
+
+            unpacked_kernel = quantizers.unpack_int4(
+                kernel, self._orig_input_dim
+            )
+
+            def grad_fn(*args, upstream=None):
+                if upstream is None:
+                    (upstream,) = args
+                float_kernel = ops.divide(
+                    ops.cast(unpacked_kernel, dtype=self.compute_dtype),
+                    kernel_scale,
+                )
+                inputs_grad = ops.matmul(upstream, ops.transpose(float_kernel))
+                return (inputs_grad, None, None)
+
+            inputs, inputs_scale = self.inputs_quantizer(inputs)
+            x = ops.matmul(inputs, unpacked_kernel)
+            x = ops.cast(x, self.compute_dtype)
+            x = ops.divide(x, ops.multiply(inputs_scale, kernel_scale))
+            return x, grad_fn
+
+        x = matmul_with_inputs_gradient(
+            inputs,
+            ops.convert_to_tensor(self._kernel),
+            ops.convert_to_tensor(self.kernel_scale),
+        )
+
+        if self.lora_enabled:
+            lora_x = ops.matmul(inputs, self.lora_kernel_a)
+            lora_x = ops.matmul(lora_x, self.lora_kernel_b)
+            x = ops.add(x, (self.lora_alpha / self.lora_rank) * lora_x)
+
+        # Add bias and activation
         if self.bias is not None:
             x = ops.add(x, self.bias)
         if self.activation is not None:
@@ -518,32 +629,117 @@ class Dense(Layer):
             )
             kernel_scale = ops.squeeze(kernel_scale, axis=0)
             del self._kernel
-        self.quantized_build(kernel_shape, mode)
-        if mode == "int8":
+            # Build variables for int8 mode
+            self.quantized_build(kernel_shape, mode)
             self._kernel.assign(kernel_value)
             self.kernel_scale.assign(kernel_scale)
+        elif mode == "int4":
+            # 1. Quantize to int4 values (still int8 dtype, range [-8,7])
+            kernel_value_int4, kernel_scale = quantizers.abs_max_quantize(
+                self._kernel,
+                axis=0,
+                value_range=(-8, 7),
+                dtype="int8",
+                to_numpy=True,
+            )
+            kernel_scale = ops.squeeze(kernel_scale, axis=0)
+            # 2. Pack two int4 values into a single int8 byte.
+            packed_kernel_value, _, _ = quantizers.pack_int4(kernel_value_int4)
+            del self._kernel
+            # Build variables using the original kernel shape; _int4_build will
+            # compute the packed shape internally.
+            self.quantized_build(kernel_shape, mode)
+            # Assign packed values.
+            self._kernel.assign(packed_kernel_value)
+            self.kernel_scale.assign(kernel_scale)
+        elif mode == "float8":
+            self.quantized_build(kernel_shape, mode)
+        else:
+            raise self._quantization_mode_error(mode)
 
-        # Set new dtype policy
+        # Set new dtype policy only for modes that already have a policy.
         if self.dtype_policy.quantization_mode is None:
+            from keras.src import dtype_policies  # local import to avoid cycle
+
             policy = dtype_policies.get(f"{mode}_from_{self.dtype_policy.name}")
             self.dtype_policy = policy
 
     def _get_kernel_with_merged_lora(self):
+        """Returns the kernel with LoRA matrices merged, for serialization.
+
+        This method is called by `save_own_variables` to produce a single
+        kernel tensor that includes the adaptations from LoRA. This is useful
+        for deploying the model or for continuing training after permanently
+        applying the LoRA update.
+
+        If the layer is quantized (`int8` or `int4`), the process is:
+        1. Dequantize the base kernel to float.
+        2. Compute the LoRA delta (`lora_kernel_a @ lora_kernel_b`) and add
+            it to the dequantized kernel.
+        3. Re-quantize the merged result back to the original quantized
+            type (`int8` or packed `int4`), calculating a new scale factor.
+
+        If the layer is not quantized, this method returns the result of the
+        `kernel` property (which computes the merge in floating-point) and a
+        scale of `None`.
+
+        If LoRA is not enabled, it returns the original kernel and scale
+        without modification.
+
+        Returns:
+            A tuple `(kernel_value, kernel_scale)`:
+                `kernel_value`: The merged kernel. A quantized tensor if
+                    quantization is active, otherwise a high precision tensor.
+                `kernel_scale`: The quantization scale for the merged kernel.
+                    This is `None` if the layer is not quantized.
+        """
         if self.dtype_policy.quantization_mode is not None:
             kernel_value = self._kernel
             kernel_scale = self.kernel_scale
             if self.lora_enabled:
-                # Dequantize & quantize to merge lora weights into int8 kernel
-                # Note that this is a lossy compression
-                kernel_value = ops.divide(kernel_value, kernel_scale)
-                kernel_value = ops.add(
-                    kernel_value,
-                    (self.lora_alpha / self.lora_rank)
-                    * ops.matmul(self.lora_kernel_a, self.lora_kernel_b),
+                # Dequantize kernel to float
+                if self.quantization_mode == "int4":
+                    unpacked_kernel = quantizers.unpack_int4(
+                        kernel_value, self._orig_input_dim
+                    )
+                    float_kernel = ops.divide(
+                        ops.cast(unpacked_kernel, self.compute_dtype),
+                        kernel_scale,
+                    )
+                    quant_range = (-8, 7)
+                elif self.quantization_mode == "int8":
+                    float_kernel = ops.divide(
+                        ops.cast(kernel_value, self.compute_dtype), kernel_scale
+                    )
+                    quant_range = (-127, 127)
+                else:
+                    raise ValueError(
+                        "Unsupported quantization mode: "
+                        f"{self.quantization_mode}"
+                    )
+
+                # Merge LoRA weights in float domain
+                lora_delta = (self.lora_alpha / self.lora_rank) * ops.matmul(
+                    self.lora_kernel_a, self.lora_kernel_b
                 )
-                kernel_value, kernel_scale = quantizers.abs_max_quantize(
-                    kernel_value, axis=0, to_numpy=True
+                merged_float_kernel = ops.add(float_kernel, lora_delta)
+
+                # Requantize
+                requantized_kernel, kernel_scale = quantizers.abs_max_quantize(
+                    merged_float_kernel,
+                    axis=0,
+                    value_range=quant_range,
+                    dtype="int8",
+                    to_numpy=True,
                 )
                 kernel_scale = ops.squeeze(kernel_scale, axis=0)
+
+                # Pack if int4
+                if self.quantization_mode == "int4":
+                    kernel_value, _, _ = quantizers.pack_int4(
+                        requantized_kernel
+                    )
+                else:
+                    kernel_value = requantized_kernel
             return kernel_value, kernel_scale
         return self.kernel, None

--- a/keras/src/layers/layer_test.py
+++ b/keras/src/layers/layer_test.py
@@ -874,42 +874,6 @@ class LayerTest(testing.TestCase):
         y = layer(x)
         self.assertAllClose(y._keras_mask, mask)
 
-    @pytest.mark.skipif(
-        backend.backend() == "numpy", reason="masking not supported with numpy"
-    )
-    def test_masking_with_explicit_kwarg_propagation(self):
-        """This test validates that an explicit `mask` kwarg is correctly
-        used to compute the output mask.
-        """
-
-        class PassthroughMaskLayer(layers.Layer):
-            def __init__(self):
-                super().__init__()
-                self.supports_masking = True
-
-            def call(self, x, mask=None):
-                # The layer itself can use the mask.
-                self.used_mask = mask is not None
-                return x
-
-        layer = PassthroughMaskLayer()
-        # Create an input tensor WITHOUT an attached mask.
-        x = backend.numpy.ones((4, 4))
-        self.assertIsNone(getattr(x, "_keras_mask", None))
-
-        # Create a mask to be passed explicitly.
-        explicit_mask = backend.numpy.array([True, True, False, False])
-
-        # Call the layer, passing the mask as a keyword argument.
-        y = layer(x, mask=explicit_mask)
-
-        # Assert that the layer's internal call received the mask.
-        self.assertTrue(layer.used_mask)
-
-        # Assert that the output tensor 'y' now has the explicit mask attached
-        # for propagation to the next layer.
-        self.assertAllClose(backend.get_keras_mask(y), explicit_mask)
-
     def test_stateless_call(self):
         class TestLayer(layers.Layer):
             def __init__(self):

--- a/keras/src/layers/preprocessing/feature_space.py
+++ b/keras/src/layers/preprocessing/feature_space.py
@@ -6,13 +6,12 @@ from keras.src.layers.layer import Layer
 from keras.src.layers.preprocessing.tf_data_layer import TFDataLayer
 from keras.src.saving import saving_lib
 from keras.src.saving import serialization_lib
-from keras.src.saving.keras_saveable import KerasSaveable
 from keras.src.utils import backend_utils
 from keras.src.utils.module_utils import tensorflow as tf
 from keras.src.utils.naming import auto_name
 
 
-class Cross(KerasSaveable):
+class Cross:
     def __init__(self, feature_names, crossing_dim, output_mode="one_hot"):
         if output_mode not in {"int", "one_hot"}:
             raise ValueError(
@@ -23,9 +22,6 @@ class Cross(KerasSaveable):
         self.feature_names = tuple(feature_names)
         self.crossing_dim = crossing_dim
         self.output_mode = output_mode
-
-    def _obj_type(self):
-        return "Cross"
 
     @property
     def name(self):
@@ -43,7 +39,7 @@ class Cross(KerasSaveable):
         return cls(**config)
 
 
-class Feature(KerasSaveable):
+class Feature:
     def __init__(self, dtype, preprocessor, output_mode):
         if output_mode not in {"int", "one_hot", "float"}:
             raise ValueError(
@@ -58,9 +54,6 @@ class Feature(KerasSaveable):
             )
         self.preprocessor = preprocessor
         self.output_mode = output_mode
-
-    def _obj_type(self):
-        return "Feature"
 
     def get_config(self):
         return {

--- a/keras/src/legacy/saving/legacy_h5_format.py
+++ b/keras/src/legacy/saving/legacy_h5_format.py
@@ -6,6 +6,7 @@ import numpy as np
 from absl import logging
 
 from keras.src import backend
+from keras.src import optimizers
 from keras.src.backend.common import global_state
 from keras.src.legacy.saving import json_utils
 from keras.src.legacy.saving import saving_options
@@ -160,8 +161,6 @@ def load_model_from_hdf5(filepath, custom_objects=None, compile=True):
             # Set optimizer weights.
             if "optimizer_weights" in f:
                 try:
-                    from keras.src import optimizers
-
                     if isinstance(model.optimizer, optimizers.Optimizer):
                         model.optimizer.build(model._trainable_variables)
                     else:
@@ -250,8 +249,6 @@ def save_optimizer_weights_to_hdf5_group(hdf5_group, optimizer):
         hdf5_group: HDF5 group.
         optimizer: optimizer instance.
     """
-    from keras.src import optimizers
-
     if isinstance(optimizer, optimizers.Optimizer):
         symbolic_weights = optimizer.variables
     else:
@@ -318,14 +315,12 @@ def save_attributes_to_hdf5_group(group, name, data):
         group.attrs[name] = data
 
 
-def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
+def load_weights_from_hdf5_group(f, model):
     """Implements topological (order-based) weight loading.
 
     Args:
         f: A pointer to a HDF5 group.
         model: Model instance.
-        skip_mismatch: Boolean, whether to skip loading of weights
-            where there is a mismatch in the shape of the weights,
 
     Raises:
         ValueError: in case of mismatch between provided layers
@@ -381,7 +376,6 @@ def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
             layer,
             symbolic_weights,
             weight_values,
-            skip_mismatch=skip_mismatch,
             name=f"layer #{k} (named {layer.name})",
         )
 
@@ -406,7 +400,6 @@ def load_weights_from_hdf5_group(f, model, skip_mismatch=False):
             model,
             symbolic_weights,
             weight_values,
-            skip_mismatch=skip_mismatch,
             name="top-level model",
         )
 

--- a/keras/src/legacy/saving/saving_utils.py
+++ b/keras/src/legacy/saving/saving_utils.py
@@ -4,8 +4,11 @@ import threading
 from absl import logging
 
 from keras.src import backend
+from keras.src import layers
 from keras.src import losses
 from keras.src import metrics as metrics_module
+from keras.src import models
+from keras.src import optimizers
 from keras.src import tree
 from keras.src.legacy.saving import serialization
 from keras.src.saving import object_registration
@@ -46,9 +49,6 @@ def model_from_config(config, custom_objects=None):
     global MODULE_OBJECTS
 
     if not hasattr(MODULE_OBJECTS, "ALL_OBJECTS"):
-        from keras.src import layers
-        from keras.src import models
-
         MODULE_OBJECTS.ALL_OBJECTS = layers.__dict__
         MODULE_OBJECTS.ALL_OBJECTS["InputLayer"] = layers.InputLayer
         MODULE_OBJECTS.ALL_OBJECTS["Functional"] = models.Functional
@@ -132,8 +132,6 @@ def compile_args_from_training_config(training_config, custom_objects=None):
         custom_objects = {}
 
     with object_registration.CustomObjectScope(custom_objects):
-        from keras.src import optimizers
-
         optimizer_config = training_config["optimizer_config"]
         optimizer = optimizers.deserialize(optimizer_config)
         # Ensure backwards compatibility for optimizers in legacy H5 files

--- a/keras/src/ops/core_test.py
+++ b/keras/src/ops/core_test.py
@@ -1151,11 +1151,6 @@ class CoreOpsDtypeTest(testing.TestCase):
             )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
-    def test_convert_to_tensor_with_variable(self, dtype):
-        x = backend.Variable(np.array([1.0, 0.0, 1.0], dtype=np.float32))
-        self.assertDType(ops.convert_to_tensor(x, dtype=dtype), dtype)
-
-    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_saturate_cast(self, dtype):
         x = np.ones((1,))
 

--- a/keras/src/ops/nn.py
+++ b/keras/src/ops/nn.py
@@ -10,6 +10,7 @@ from keras.src.backend import standardize_data_format
 from keras.src.backend.common.backend_utils import (
     compute_conv_transpose_output_shape,
 )
+from keras.src.backend.common.keras_tensor import is_keras_tensor
 from keras.src.ops import operation_utils
 from keras.src.ops.operation import Operation
 from keras.src.ops.operation_utils import reduce_shape
@@ -2752,17 +2753,18 @@ def dot_product_attention(
 
 
 class RMSNorm(Operation):
-    def __init__(self, axis=-1, epsilon=None, *, name=None):
+    def __init__(self, scale=1, axis=-1, epsilon=None, *, name=None):
         super().__init__(name=name)
         self.axis = axis
+        self.scale = scale
         self.epsilon = epsilon
 
-    def compute_output_spec(self, x, scale):
-        return KerasTensor(shape=x.shape, dtype=x.dtype)
+    def compute_output_spec(self, x):
+        return KerasTensor(shape=x.shape)
 
-    def call(self, x, scale=None):
+    def call(self, x):
         return _rms_normalization(
-            x, scale=scale, axis=self.axis, epsilon=self.epsilon
+            x, scale=self.scale, axis=self.axis, epsilon=self.epsilon
         )
 
 
@@ -2772,7 +2774,7 @@ class RMSNorm(Operation):
         "keras.ops.nn.rms_normalization",
     ]
 )
-def rms_normalization(x, scale=None, axis=-1, epsilon=None):
+def rms_normalization(x, scale=1, axis=-1, epsilon=None):
     """Performs Root Mean Square (RMS) normalization on `x`.
 
     The Keras operation implements the operation as described in
@@ -2785,77 +2787,81 @@ def rms_normalization(x, scale=None, axis=-1, epsilon=None):
 
     Args:
         x: Input tensor.
+        axis: The axis or axes along which to perform normalization.
+            Default to -1.
         scale: Optional scaling factor for the normalization.
-        axis: The axis or axes along which to perform normalization. Defaults
-            to `-1`.
-        epsilon: A lower bound value for the norm. Defaults to
-            `backend.epsilon()`.
+        epsilon: A lower bound value for the norm.
+            Defaults to `backend.epsilon()`.
 
     Returns:
         The normalized array.
 
     Example:
 
-    >>> x = keras.random.normal((1, 10))
-    >>> keras.ops.rms_normalization(x)
+    >>> x = np.random.rand(1, 10)
+    >>> x_norm = keras.ops.rms_normalization(x, (10,))
+    >>> print(x_norm)
     array([[0.69384296, 0.94444374, 0.16551171, 0.05749961, 1.11008865,
-            0.52475186, 1.57686807, 1.69893307, 1.27292764, 0.30819128]])
+        0.52475186, 1.57686807, 1.69893307, 1.27292764, 0.30819128]])
     """
-    if any_symbolic_tensors((x, scale)):
-        return RMSNorm(axis=axis, epsilon=epsilon).symbolic_call(x, scale=scale)
+    if any_symbolic_tensors((x,)):
+        return RMSNorm(scale=scale, axis=axis, epsilon=epsilon).symbolic_call(x)
     return _rms_normalization(x, scale=scale, axis=axis, epsilon=epsilon)
 
 
-def _rms_normalization(x, scale=None, axis=-1, epsilon=None):
-    if epsilon is None:
-        epsilon = backend.epsilon()
-    original_dtype = backend.standardize_dtype(x.dtype)
-    # Computes in at least float32 precision for stability in half precision
-    # training.
-    compute_dtype = backend.result_type(x.dtype, "float32")
-
-    x = backend.convert_to_tensor(x, dtype=compute_dtype)
-    if scale is not None:
-        scale = backend.convert_to_tensor(scale, x.dtype)
-
+def _rms_normalization(x, scale=1, axis=-1, epsilon=None):
     if backend.backend() == "torch" and is_continuous_axis(axis):
         import torch.nn.functional as F
 
         if isinstance(axis, (tuple, list)):
             normalized_shape = tuple([x.shape[dim] for dim in axis])
         else:
-            normalized_shape = (x.shape[axis],)
-        outputs = F.rms_norm(x, normalized_shape, scale, epsilon)
-    else:
-        if len(x.shape) == 0:
-            x = backend.numpy.expand_dims(x, axis=0)
-        rrms = backend.math.rsqrt(
-            backend.numpy.mean(
-                backend.numpy.square(x), axis=axis, keepdims=True
-            )
-            + epsilon
-        )
-        outputs = backend.numpy.multiply(x, rrms)
-        if scale is not None:
-            outputs = backend.numpy.multiply(outputs, scale)
-    return backend.cast(outputs, original_dtype)
+            normalized_shape = x.shape[axis]
+        return F.rms_norm(x, normalized_shape, scale, epsilon)
+    x = backend.convert_to_tensor(x)
+    if len(x.shape) == 0:
+        x = backend.numpy.expand_dims(x, axis=0)
+    if epsilon is None:
+        epsilon = backend.epsilon()
+
+    if not is_keras_tensor(scale):
+        scale = backend.convert_to_tensor(scale, dtype=x.dtype)
+    if not is_keras_tensor(epsilon):
+        epsilon = backend.convert_to_tensor(epsilon, dtype=x.dtype)
+
+    rrms = backend.math.rsqrt(
+        backend.numpy.mean(backend.numpy.square(x), axis=axis, keepdims=True)
+        + epsilon
+    )
+    return (x * rrms) * scale
 
 
 class LayerNorm(Operation):
-    def __init__(self, axis=-1, epsilon=None, rms_scaling=False, *, name=None):
+    def __init__(
+        self,
+        gamma=None,
+        beta=None,
+        axis=-1,
+        epsilon=None,
+        rms_scaling=False,
+        *,
+        name=None,
+    ):
         super().__init__(name=name)
         self.axis = axis
+        self.gamma = gamma
+        self.beta = beta
         self.epsilon = epsilon
         self.rms_scaling = rms_scaling
 
-    def compute_output_spec(self, x, gamma, beta):
-        return KerasTensor(shape=x.shape, dtype=x.dtype)
+    def compute_output_spec(self, x):
+        return KerasTensor(shape=x.shape)
 
-    def call(self, x, gamma=None, beta=None):
-        return _layer_normalization(
+    def call(self, x):
+        return _rms_normalization(
             x,
-            gamma=gamma,
-            beta=beta,
+            gamma=self.gamma,
+            beta=self.beta,
             axis=self.axis,
             epsilon=self.epsilon,
             rms_scaling=self.rms_scaling,
@@ -2877,24 +2883,21 @@ def layer_normalization(
     batch independently, rather than across a batch like Batch Normalization.
     i.e. applies a transformation that maintains the mean activation within each
     example close to 0 and the activation standard deviation close to 1.
-
     Args:
         x: Input tensor.
+        axis: The axis or axes along which to perform normalization.
+            Default to -1.
         gamma: Optional scaling factor for the normalization.
         beta: Optional add offset for the normalized tensor.
-        axis: The axis or axes along which to perform normalization. Default to
-            `-1`.
         epsilon: A lower bound value for the norm.
             Defaults to `backend.epsilon()`.
 
     Returns:
         The normalized array.
-
-    Example:
-
-    >>> x = keras.ops.arange(5, dtype="float32")
-    >>> keras.ops.layer_normalization(x)
-    array([-1.4142135, -0.70710677, 0.0, 0.7071067, 1.4142135])
+    >>> x = ops.arange(5,dtype = "float32")
+    >>> x_norm = ops.layer_normalization(x)
+    >>> print(x_norm)
+    array([-1.4142135 , -0.70710677,  0.,  0.7071067 ,  1.4142135 ])
     """
     rms_scaling = kwargs.pop("rms_scaling", False)
     if rms_scaling:
@@ -2906,10 +2909,14 @@ def layer_normalization(
             "instead."
         )
 
-    if any_symbolic_tensors((x, gamma, beta)):
+    if any_symbolic_tensors((x,)):
         return LayerNorm(
-            axis=axis, epsilon=epsilon, rms_scaling=rms_scaling
-        ).symbolic_call(x, gamma, beta)
+            gamma=gamma,
+            beta=beta,
+            axis=axis,
+            epsilon=epsilon,
+            rms_scaling=rms_scaling,
+        ).symbolic_call(x)
     return _layer_normalization(
         x,
         gamma=gamma,
@@ -2921,21 +2928,12 @@ def layer_normalization(
 
 
 def _layer_normalization(
-    x, gamma=None, beta=None, axis=-1, epsilon=None, rms_scaling=False
+    inputs, gamma=None, beta=None, axis=-1, epsilon=None, rms_scaling=False
 ):
-    if epsilon is None:
-        epsilon = backend.epsilon()
-    original_dtype = backend.standardize_dtype(x.dtype)
-    # Computes in at least float32 precision for stability in half precision
-    # training.
-    compute_dtype = backend.result_type(x.dtype, "float32")
-
-    x = backend.convert_to_tensor(x, dtype=compute_dtype)
-    if gamma is not None:
-        gamma = backend.convert_to_tensor(gamma, x.dtype)
-    if beta is not None:
-        beta = backend.convert_to_tensor(beta, x.dtype)
-
+    compute_dtype = backend.result_type(inputs.dtype, "float32")
+    # LN is prone to overflow with float16/bfloat16 inputs, so we upcast to
+    # float32 for the subsequent computations.
+    x = backend.cast(inputs, compute_dtype)
     # Compute the axes along which to reduce the mean / variance
     input_shape = x.shape
     ndims = len(input_shape)
@@ -2953,12 +2951,16 @@ def _layer_normalization(
             return backend.numpy.reshape(v, broadcast_shape)
         return v
 
+    if epsilon is None:
+        epsilon = backend.epsilon()
+
     if rms_scaling:
+        # Calculate outputs with only variance and gamma if rms scaling
+        # is enabled
+        # Calculate the variance along self.axis (layer activations).
         variance = backend.numpy.var(x, axis=axis, keepdims=True)
         inv = backend.math.rsqrt(variance + epsilon)
-        outputs = outputs = x * inv
-        if gamma is not None:
-            outputs = outputs * backend.cast(_broadcast(gamma), x.dtype)
+        outputs = x * inv * backend.cast(_broadcast(gamma), x.dtype)
     elif backend.config.backend() == "torch" and is_continuous_axis(axis):
         # when using torch backend,use kernel to improve performance
         import torch.nn.functional as F
@@ -2971,14 +2973,16 @@ def _layer_normalization(
         gamma, beta = _broadcast(gamma), _broadcast(beta)
         inv = backend.math.rsqrt(variance + epsilon)
         if gamma is not None:
+            gamma = backend.cast(gamma, x.dtype)
             inv = inv * gamma
 
         res = -mean * inv
         if beta is not None:
+            beta = backend.cast(beta, x.dtype)
             res = res + beta
 
         outputs = x * inv + res
-    return backend.cast(outputs, original_dtype)
+    return backend.cast(outputs, inputs.dtype)
 
 
 class Polar(Operation):

--- a/keras/src/ops/nn_test.py
+++ b/keras/src/ops/nn_test.py
@@ -775,19 +775,6 @@ class NNOpsDynamicShapeTest(testing.TestCase):
         out = knn.dot_product_attention(query, key, value)
         self.assertEqual(out.shape, query.shape)
 
-    def test_rms_normalization(self):
-        x = KerasTensor([None, 8, 16])
-        scale = KerasTensor([None, 8, 16])
-        out = knn.rms_normalization(x, scale)
-        self.assertEqual(out.shape, x.shape)
-
-    def test_layer_normalization(self):
-        x = KerasTensor([None, 8, 16])
-        gamma = KerasTensor([None, 16])
-        beta = KerasTensor([None, 16])
-        out = knn.layer_normalization(x, gamma, beta)
-        self.assertEqual(out.shape, x.shape)
-
 
 class NNOpsStaticShapeTest(testing.TestCase):
     def test_relu(self):
@@ -1304,17 +1291,6 @@ class NNOpsStaticShapeTest(testing.TestCase):
         value = KerasTensor([2, 4, 6, 16])
         out = knn.dot_product_attention(query, key, value)
         self.assertEqual(out.shape, query.shape)
-
-    def test_rms_normalization(self):
-        x = KerasTensor([2, 8, 16])
-        scale = KerasTensor([2, 8, 16])
-        self.assertEqual(knn.rms_normalization(x, scale).shape, x.shape)
-
-    def test_layer_normalization(self):
-        x = KerasTensor([2, 8, 16])
-        gamma = KerasTensor([2, 16])
-        beta = KerasTensor([2, 16])
-        self.assertEqual(knn.layer_normalization(x, gamma, beta).shape, x.shape)
 
     def test_polar(self):
         abs_ = KerasTensor([1, 2])
@@ -2523,31 +2499,6 @@ class NNOpsCorrectnessTest(testing.TestCase):
             outputs, expected, atol=1e-3 if flash_attention else 1e-6
         )
 
-    @parameterized.named_parameters(named_product(scale=(1.0, 10.0)))
-    def test_rms_normalization(self, scale):
-        x = np.array([[0.1, 0.2, 0.3], [0.4, 0.5, 0.6]], dtype="float32")
-        scale = np.array([scale] * x.shape[-1], dtype="float32")
-        expected_output = (
-            np.array([[0.46291, 0.92582, 1.38873], [0.78954, 0.98693, 1.18431]])
-            * scale
-        )
-
-        self.assertAllClose(
-            knn.rms_normalization(x, scale), expected_output, atol=1e-3
-        )
-        self.assertAllClose(knn.RMSNorm()(x, scale), expected_output, atol=1e-3)
-
-    def test_layer_normalization(self):
-        x = np.arange(5, dtype="float32")
-        expected_output = np.array(
-            [-1.4142135, -0.70710677, 0.0, 0.7071067, 1.4142135]
-        )
-
-        self.assertAllClose(
-            knn.layer_normalization(x), expected_output, atol=1e-3
-        )
-        self.assertAllClose(knn.LayerNorm()(x), expected_output, atol=1e-3)
-
 
 class NNOpsDtypeTest(testing.TestCase):
     """Test the dtype to verify that the behavior matches JAX."""
@@ -3131,37 +3082,6 @@ class NNOpsDtypeTest(testing.TestCase):
             expected_dtype,
         )
 
-    @parameterized.named_parameters(
-        named_product(dtypes=combinations(FLOAT_DTYPES, 2))
-    )
-    def test_rms_normalization(self, dtypes):
-        input_dtype, weight_dtype = dtypes
-        inputs = knp.ones((2, 8), dtype=input_dtype)
-        scale = backend.Variable(knp.ones((8,), dtype=weight_dtype))
-        expected_dtype = input_dtype
-
-        self.assertDType(knn.rms_normalization(inputs, scale), expected_dtype)
-        self.assertDType(
-            knn.RMSNorm().symbolic_call(inputs, scale), expected_dtype
-        )
-
-    @parameterized.named_parameters(
-        named_product(dtypes=combinations(FLOAT_DTYPES, 2))
-    )
-    def test_layer_normalization(self, dtypes):
-        input_dtype, weight_dtype = dtypes
-        inputs = knp.ones((2, 8), dtype=input_dtype)
-        gamma = backend.Variable(knp.ones((8,), dtype=weight_dtype))
-        beta = backend.Variable(knp.ones((8,), dtype=weight_dtype))
-        expected_dtype = input_dtype
-
-        self.assertDType(
-            knn.layer_normalization(inputs, gamma, beta), expected_dtype
-        )
-        self.assertDType(
-            knn.LayerNorm().symbolic_call(inputs, gamma, beta), expected_dtype
-        )
-
 
 class NNOpsBehaviorTest(testing.TestCase):
     def test_logit_recovery_binary_crossentropy(self):
@@ -3253,9 +3173,14 @@ class NNOpsBehaviorTest(testing.TestCase):
                 top_paths=top_paths,
             )
 
-    def test_layer_normalization_rms_scaling_warning(self):
-        x = np.arange(5, dtype="float32")
-        with self.assertWarnsRegex(
-            UserWarning, r"You passed `rms_scaling=True`, which is deprecated"
-        ):
-            knn.layer_normalization(x, rms_scaling=True)
+    def test_rms_normalization(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(
+            knn.rms_normalization(x, (None, 2, 3)).shape, (None, 2, 3)
+        )
+
+    def test_layer_normalization(self):
+        x = KerasTensor([None, 2, 3])
+        self.assertEqual(
+            knn.layer_normalization(x, (None, 2, 3)).shape, (None, 2, 3)
+        )

--- a/keras/src/ops/numpy.py
+++ b/keras/src/ops/numpy.py
@@ -1779,29 +1779,6 @@ def broadcast_to(x, shape):
     return backend.numpy.broadcast_to(x, shape)
 
 
-class Cbrt(Operation):
-    def call(self, x):
-        return backend.numpy.cbrt(x)
-
-
-@keras_export(["keras.ops.cbrt", "keras.ops.numpy.cbrt"])
-def cbrt(x):
-    """Computes the cube root of the input tensor, element-wise.
-
-    This operation returns the real-valued cube root of `x`, handling
-    negative numbers properly in the real domain.
-
-    Args:
-        x: Input tensor.
-
-    Returns:
-        A tensor containing the cube root of each element in `x`.
-    """
-    if any_symbolic_tensors((x,)):
-        return Cbrt().symbolic_call(x)
-    return backend.numpy.cbrt(x)
-
-
 class Ceil(Operation):
     def call(self, x):
         return backend.numpy.ceil(x)
@@ -2279,36 +2256,6 @@ def cumsum(x, axis=None, dtype=None):
         Output tensor.
     """
     return Cumsum(axis=axis, dtype=dtype)(x)
-
-
-class Deg2rad(Operation):
-    def call(self, x):
-        return backend.numpy.deg2rad(x)
-
-
-@keras_export(["keras.ops.deg2rad", "keras.ops.numpy.deg2rad"])
-def deg2rad(x):
-    """Convert angles from degrees to radians.
-
-    The conversion is defined as:
-    `rad = deg * (π / 180)`
-
-    Args:
-        x: Input tensor of angles in degrees.
-
-    Returns:
-        A tensor containing angles converted to radians.
-
-    Examples:
-    >>> from keras import ops
-    >>> ops.deg2rad(180.0)
-    3.141592653589793
-    >>> ops.deg2rad([0.0, 90.0, 180.0])
-    array([0., 1.57079633, 3.14159265])
-    """
-    if any_symbolic_tensors((x,)):
-        return Deg2rad().symbolic_call(x)
-    return backend.numpy.deg2rad(x)
 
 
 class Diag(Operation):

--- a/keras/src/ops/numpy_test.py
+++ b/keras/src/ops/numpy_test.py
@@ -1255,10 +1255,6 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
             x = KerasTensor((3, 3))
             knp.broadcast_to(x, (2, 2, 3))
 
-    def test_cbrt(self):
-        x = KerasTensor((None, 3))
-        self.assertEqual(knp.cbrt(x).shape, (None, 3))
-
     def test_ceil(self):
         x = KerasTensor((None, 3))
         self.assertEqual(knp.ceil(x).shape, (None, 3))
@@ -1349,10 +1345,6 @@ class NumpyOneInputOpsDynamicShapeTest(testing.TestCase):
 
         x = KerasTensor((None, 3, 3))
         self.assertEqual(knp.cumsum(x, axis=1).shape, (None, 3, 3))
-
-    def test_deg2rad(self):
-        x = KerasTensor((None, 3))
-        self.assertEqual(knp.deg2rad(x).shape, (None, 3))
 
     def test_diag(self):
         x = KerasTensor((None, 3))
@@ -1879,10 +1871,6 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
             x = KerasTensor((3, 3))
             knp.broadcast_to(x, (2, 2, 3))
 
-    def test_cbrt(self):
-        x = KerasTensor((2, 3))
-        self.assertEqual(knp.cbrt(x).shape, (2, 3))
-
     def test_ceil(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.ceil(x).shape, (2, 3))
@@ -1931,10 +1919,6 @@ class NumpyOneInputOpsStaticShapeTest(testing.TestCase):
     def test_cumsum(self):
         x = KerasTensor((2, 3))
         self.assertEqual(knp.cumsum(x).shape, (6,))
-
-    def test_deg2rad(self):
-        x = KerasTensor((2, 3))
-        self.assertEqual(knp.deg2rad(x).shape, (2, 3))
 
     def test_diag(self):
         x = KerasTensor((3,))
@@ -3745,17 +3729,6 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             np.broadcast_to(x, [2, 2, 3]),
         )
 
-    def test_cbrt(self):
-        x = np.array([[-8, -1, 0], [1, 8, 27]], dtype="float32")
-        ref_y = np.sign(x) * np.abs(x) ** (1.0 / 3.0)
-        y = knp.cbrt(x)
-        self.assertEqual(standardize_dtype(y.dtype), "float32")
-        self.assertAllClose(y, ref_y)
-
-        y = knp.Cbrt()(x)
-        self.assertEqual(standardize_dtype(y.dtype), "float32")
-        self.assertAllClose(y, ref_y)
-
     def test_ceil(self):
         x = np.array([[1.2, 2.1, -2.5], [2.4, -11.9, -5.5]])
         self.assertAllClose(knp.ceil(x), np.ceil(x))
@@ -3937,11 +3910,6 @@ class NumpyOneInputOpsCorrectnessTest(testing.TestCase):
             knp.Cumsum(axis=axis, dtype=dtype)(x),
             np.cumsum(x, axis=axis, dtype=dtype or x.dtype),
         )
-
-    def test_deg2rad(self):
-        x = np.random.uniform(-360, 360, size=(3, 3))
-        self.assertAllClose(knp.deg2rad(x), np.deg2rad(x))
-        self.assertAllClose(knp.Deg2rad()(x), np.deg2rad(x))
 
     def test_diag(self):
         x = np.array([1, 2, 3])
@@ -6499,20 +6467,6 @@ class NumpyDtypeTest(testing.TestCase):
         )
 
     @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
-    def test_cbrt(self, dtype):
-        import jax.numpy as jnp
-
-        x1 = knp.ones((1,), dtype=dtype)
-        x1_jax = jnp.ones((1,), dtype=dtype)
-        expected_dtype = standardize_dtype(jnp.cbrt(x1_jax).dtype)
-
-        self.assertEqual(standardize_dtype(knp.cbrt(x1).dtype), expected_dtype)
-        self.assertEqual(
-            standardize_dtype(knp.Cbrt().symbolic_call(x1).dtype),
-            expected_dtype,
-        )
-
-    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
     def test_ceil(self, dtype):
         import jax.numpy as jnp
 
@@ -6720,23 +6674,6 @@ class NumpyDtypeTest(testing.TestCase):
         self.assertEqual(standardize_dtype(knp.cumsum(x).dtype), expected_dtype)
         self.assertEqual(
             standardize_dtype(knp.Cumsum().symbolic_call(x).dtype),
-            expected_dtype,
-        )
-
-    @parameterized.named_parameters(named_product(dtype=ALL_DTYPES))
-    def test_deg2rad(self, dtype):
-        import jax.numpy as jnp
-
-        x = knp.ones((1,), dtype=dtype)
-        x_jax = jnp.ones((1,), dtype=dtype)
-        expected_dtype = standardize_dtype(jnp.deg2rad(x_jax).dtype)
-
-        self.assertEqual(
-            standardize_dtype(knp.deg2rad(x).dtype), expected_dtype
-        )
-
-        self.assertEqual(
-            standardize_dtype(knp.Deg2rad().symbolic_call(x).dtype),
             expected_dtype,
         )
 

--- a/keras/src/ops/operation.py
+++ b/keras/src/ops/operation.py
@@ -7,14 +7,13 @@ from keras.src import tree
 from keras.src.api_export import keras_export
 from keras.src.backend.common.keras_tensor import any_symbolic_tensors
 from keras.src.ops.node import Node
-from keras.src.saving.keras_saveable import KerasSaveable
 from keras.src.utils import python_utils
 from keras.src.utils import traceback_utils
 from keras.src.utils.naming import auto_name
 
 
 @keras_export("keras.Operation")
-class Operation(KerasSaveable):
+class Operation:
     def __init__(self, name=None):
         if name is None:
             name = auto_name(self.__class__.__name__)
@@ -311,9 +310,6 @@ class Operation(KerasSaveable):
             return values[0]
         else:
             return values
-
-    def _obj_type(self):
-        return "Operation"
 
     # Hooks for backend layer classes
     def _post_build(self):

--- a/keras/src/quantizers/__init__.py
+++ b/keras/src/quantizers/__init__.py
@@ -7,7 +7,9 @@ from keras.src.quantizers.quantizers import abs_max_quantize
 from keras.src.quantizers.quantizers import compute_float8_amax_history
 from keras.src.quantizers.quantizers import compute_float8_scale
 from keras.src.quantizers.quantizers import fake_quant_with_min_max_vars
+from keras.src.quantizers.quantizers import pack_int4
 from keras.src.quantizers.quantizers import quantize_and_dequantize
+from keras.src.quantizers.quantizers import unpack_int4
 from keras.src.saving import serialization_lib
 from keras.src.utils.naming import to_snake_case
 

--- a/keras/src/saving/saving_api.py
+++ b/keras/src/saving/saving_api.py
@@ -249,35 +249,18 @@ def save_weights(
 @keras_export("keras.saving.load_weights")
 def load_weights(model, filepath, skip_mismatch=False, **kwargs):
     filepath_str = str(filepath)
-
-    # Get the legacy kwargs.
-    objects_to_skip = kwargs.pop("objects_to_skip", None)
-    by_name = kwargs.pop("by_name", None)
-    if kwargs:
-        raise ValueError(f"Invalid keyword arguments: {kwargs}")
-
     if filepath_str.endswith(".keras"):
-        if objects_to_skip is not None:
-            raise ValueError(
-                "`objects_to_skip` only supports loading '.weights.h5' files."
-                f"Received: {filepath}"
-            )
-        if by_name is not None:
-            raise ValueError(
-                "`by_name` only supports loading legacy '.h5' or '.hdf5' "
-                f"files. Received: {filepath}"
-            )
+        if kwargs:
+            raise ValueError(f"Invalid keyword arguments: {kwargs}")
         saving_lib.load_weights_only(
             model, filepath, skip_mismatch=skip_mismatch
         )
     elif filepath_str.endswith(".weights.h5") or filepath_str.endswith(
         ".weights.json"
     ):
-        if by_name is not None:
-            raise ValueError(
-                "`by_name` only supports loading legacy '.h5' or '.hdf5' "
-                f"files. Received: {filepath}"
-            )
+        objects_to_skip = kwargs.pop("objects_to_skip", None)
+        if kwargs:
+            raise ValueError(f"Invalid keyword arguments: {kwargs}")
         saving_lib.load_weights_only(
             model,
             filepath,
@@ -285,14 +268,12 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
             objects_to_skip=objects_to_skip,
         )
     elif filepath_str.endswith(".h5") or filepath_str.endswith(".hdf5"):
+        by_name = kwargs.pop("by_name", False)
+        if kwargs:
+            raise ValueError(f"Invalid keyword arguments: {kwargs}")
         if not h5py:
             raise ImportError(
                 "Loading a H5 file requires `h5py` to be installed."
-            )
-        if objects_to_skip is not None:
-            raise ValueError(
-                "`objects_to_skip` only supports loading '.weights.h5' files."
-                f"Received: {filepath}"
             )
         with h5py.File(filepath, "r") as f:
             if "layer_names" not in f.attrs and "model_weights" in f:
@@ -302,9 +283,7 @@ def load_weights(model, filepath, skip_mismatch=False, **kwargs):
                     f, model, skip_mismatch
                 )
             else:
-                legacy_h5_format.load_weights_from_hdf5_group(
-                    f, model, skip_mismatch
-                )
+                legacy_h5_format.load_weights_from_hdf5_group(f, model)
     else:
         raise ValueError(
             f"File format not supported: filepath={filepath}. "

--- a/keras/src/saving/saving_api_test.py
+++ b/keras/src/saving/saving_api_test.py
@@ -7,7 +7,6 @@ from absl import logging
 from absl.testing import parameterized
 
 from keras.src import layers
-from keras.src.legacy.saving.legacy_h5_format import save_model_to_hdf5
 from keras.src.models import Sequential
 from keras.src.saving import saving_api
 from keras.src.testing import test_case
@@ -54,18 +53,7 @@ class SaveModelTests(test_case.TestCase):
         """Test saving model in h5 format."""
         model = self.get_model()
         filepath_h5 = os.path.join(self.get_temp_dir(), "test_model.h5")
-
-        # Verify the warning.
-        with mock.patch.object(logging, "warning") as mock_warn:
-            saving_api.save_model(model, filepath_h5)
-            mock_warn.assert_called_once_with(
-                "You are saving your model as an HDF5 file via "
-                "`model.save()` or `keras.saving.save_model(model)`. "
-                "This file format is considered legacy. "
-                "We recommend using instead the native Keras format, "
-                "e.g. `model.save('my_model.keras')` or "
-                "`keras.saving.save_model(model, 'my_model.keras')`. "
-            )
+        saving_api.save_model(model, filepath_h5)
         self.assertTrue(os.path.exists(filepath_h5))
         os.remove(filepath_h5)
 
@@ -215,36 +203,18 @@ class LoadWeightsTests(test_case.TestCase):
 
     @parameterized.named_parameters(
         named_product(
-            save_format=["keras", "weights.h5", "h5"],
             source_dtype=["float64", "float32", "float16", "bfloat16"],
             dest_dtype=["float64", "float32", "float16", "bfloat16"],
         )
     )
-    def test_load_weights(self, save_format, source_dtype, dest_dtype):
+    def test_load_keras_weights(self, source_dtype, dest_dtype):
         """Test loading keras weights."""
         src_model = self.get_model(dtype=source_dtype)
-        if save_format == "keras":
-            filepath = os.path.join(self.get_temp_dir(), "test_weights.keras")
-            src_model.save(filepath)
-        elif save_format == "weights.h5":
-            filepath = os.path.join(
-                self.get_temp_dir(), "test_weights.weights.h5"
-            )
-            src_model.save_weights(filepath)
-        elif save_format == "h5":
-            if "bfloat16" in (source_dtype, dest_dtype):
-                raise self.skipTest(
-                    "bfloat16 dtype is not supported in legacy h5 format."
-                )
-            filepath = os.path.join(self.get_temp_dir(), "test_weights.h5")
-            save_model_to_hdf5(src_model, filepath)
-        else:
-            raise ValueError(f"Unsupported save format: {save_format}")
-
+        filepath = os.path.join(self.get_temp_dir(), "test_weights.weights.h5")
+        src_model.save_weights(filepath)
+        src_weights = src_model.get_weights()
         dest_model = self.get_model(dtype=dest_dtype)
         dest_model.load_weights(filepath)
-
-        src_weights = src_model.get_weights()
         dest_weights = dest_model.get_weights()
         for orig, loaded in zip(src_weights, dest_weights):
             self.assertAllClose(
@@ -254,41 +224,13 @@ class LoadWeightsTests(test_case.TestCase):
                 rtol=0.01,
             )
 
-    def test_load_weights_invalid_kwargs(self):
-        src_model = self.get_model()
-        keras_filepath = os.path.join(self.get_temp_dir(), "test_weights.keras")
-        weight_h5_filepath = os.path.join(
-            self.get_temp_dir(), "test_weights.weights.h5"
-        )
-        legacy_h5_filepath = os.path.join(
-            self.get_temp_dir(), "test_weights.h5"
-        )
-        src_model.save(keras_filepath)
-        src_model.save_weights(weight_h5_filepath)
-        save_model_to_hdf5(src_model, legacy_h5_filepath)
-
-        dest_model = self.get_model()
-        # Test keras file.
-        with self.assertRaisesRegex(
-            ValueError, r"only supports loading '.weights.h5' files."
-        ):
-            dest_model.load_weights(keras_filepath, objects_to_skip=[])
-        with self.assertRaisesRegex(
-            ValueError, r"only supports loading legacy '.h5' or '.hdf5' files."
-        ):
-            dest_model.load_weights(keras_filepath, by_name=True)
-        with self.assertRaisesRegex(ValueError, r"Invalid keyword arguments"):
-            dest_model.load_weights(keras_filepath, bad_kwarg=None)
-        # Test weights.h5 file.
-        with self.assertRaisesRegex(
-            ValueError, r"only supports loading legacy '.h5' or '.hdf5' files."
-        ):
-            dest_model.load_weights(weight_h5_filepath, by_name=True)
-        # Test h5 file.
-        with self.assertRaisesRegex(
-            ValueError, r"only supports loading '.weights.h5' files."
-        ):
-            dest_model.load_weights(legacy_h5_filepath, objects_to_skip=[])
+    def test_load_h5_weights_by_name(self):
+        """Test loading h5 weights by name."""
+        model = self.get_model()
+        filepath = os.path.join(self.get_temp_dir(), "test_weights.weights.h5")
+        model.save_weights(filepath)
+        with self.assertRaisesRegex(ValueError, "Invalid keyword arguments"):
+            model.load_weights(filepath, by_name=True)
 
     def test_load_weights_invalid_extension(self):
         """Test loading weights with unsupported extension."""
@@ -309,3 +251,29 @@ class LoadWeightsTests(test_case.TestCase):
         dest_weights = dest_model.get_weights()
         for orig, loaded in zip(src_weights, dest_weights):
             self.assertAllClose(orig, loaded)
+
+
+class SaveModelTestsWarning(test_case.TestCase):
+    def get_model(self):
+        return Sequential(
+            [
+                layers.Dense(5, input_shape=(3,)),
+                layers.Softmax(),
+            ]
+        )
+
+    def test_h5_deprecation_warning(self):
+        """Test deprecation warning for h5 format."""
+        model = self.get_model()
+        filepath = os.path.join(self.get_temp_dir(), "test_model.h5")
+
+        with mock.patch.object(logging, "warning") as mock_warn:
+            saving_api.save_model(model, filepath)
+            mock_warn.assert_called_once_with(
+                "You are saving your model as an HDF5 file via "
+                "`model.save()` or `keras.saving.save_model(model)`. "
+                "This file format is considered legacy. "
+                "We recommend using instead the native Keras format, "
+                "e.g. `model.save('my_model.keras')` or "
+                "`keras.saving.save_model(model, 'my_model.keras')`. "
+            )

--- a/keras/src/saving/saving_lib.py
+++ b/keras/src/saving/saving_lib.py
@@ -16,9 +16,14 @@ import numpy as np
 
 from keras.src import backend
 from keras.src.backend.common import global_state
+from keras.src.layers.layer import Layer
+from keras.src.losses.loss import Loss
+from keras.src.metrics.metric import Metric
+from keras.src.optimizers.optimizer import Optimizer
 from keras.src.saving.serialization_lib import ObjectSharingScope
 from keras.src.saving.serialization_lib import deserialize_keras_object
 from keras.src.saving.serialization_lib import serialize_keras_object
+from keras.src.trainers.compile_utils import CompileMetrics
 from keras.src.utils import dtype_utils
 from keras.src.utils import file_utils
 from keras.src.utils import io_utils
@@ -1579,60 +1584,32 @@ def get_attr_skipset(obj_type):
             "_self_unconditional_dependency_names",
         ]
     )
-    if obj_type == "Operation":
-        from keras.src.ops.operation import Operation
-
-        ref_obj = Operation()
-        skipset.update(dir(ref_obj))
     if obj_type == "Layer":
-        from keras.src.layers.layer import Layer
-
         ref_obj = Layer()
         skipset.update(dir(ref_obj))
     elif obj_type == "Functional":
-        from keras.src.layers.layer import Layer
-
         ref_obj = Layer()
         skipset.update(dir(ref_obj) + ["operations", "_operations"])
     elif obj_type == "Sequential":
-        from keras.src.layers.layer import Layer
-
         ref_obj = Layer()
         skipset.update(dir(ref_obj) + ["_functional"])
     elif obj_type == "Metric":
-        from keras.src.metrics.metric import Metric
-        from keras.src.trainers.compile_utils import CompileMetrics
-
         ref_obj_a = Metric()
         ref_obj_b = CompileMetrics([], [])
         skipset.update(dir(ref_obj_a) + dir(ref_obj_b))
     elif obj_type == "Optimizer":
-        from keras.src.optimizers.optimizer import Optimizer
-
         ref_obj = Optimizer(1.0)
         skipset.update(dir(ref_obj))
         skipset.remove("variables")
     elif obj_type == "Loss":
-        from keras.src.losses.loss import Loss
-
         ref_obj = Loss()
-        skipset.update(dir(ref_obj))
-    elif obj_type == "Cross":
-        from keras.src.layers.preprocessing.feature_space import Cross
-
-        ref_obj = Cross((), 1)
-        skipset.update(dir(ref_obj))
-    elif obj_type == "Feature":
-        from keras.src.layers.preprocessing.feature_space import Feature
-
-        ref_obj = Feature("int32", lambda x: x, "int")
         skipset.update(dir(ref_obj))
     else:
         raise ValueError(
             f"get_attr_skipset got invalid {obj_type=}. "
             "Accepted values for `obj_type` are "
             "['Layer', 'Functional', 'Sequential', 'Metric', "
-            "'Optimizer', 'Loss', 'Cross', 'Feature']"
+            "'Optimizer', 'Loss']"
         )
 
     global_state.set_global_attribute(

--- a/keras/src/saving/serialization_lib.py
+++ b/keras/src/saving/serialization_lib.py
@@ -12,7 +12,6 @@ from keras.src import backend
 from keras.src.api_export import keras_export
 from keras.src.backend.common import global_state
 from keras.src.saving import object_registration
-from keras.src.saving.keras_saveable import KerasSaveable
 from keras.src.utils import python_utils
 from keras.src.utils.module_utils import tensorflow as tf
 
@@ -33,7 +32,6 @@ BUILTIN_MODULES = frozenset(
 
 LOADING_APIS = frozenset(
     {
-        "keras.config.enable_unsafe_deserialization",
         "keras.models.load_model",
         "keras.preprocessing.image.load_img",
         "keras.saving.load_model",
@@ -819,13 +817,8 @@ def _retrieve_class_or_fn(
             try:
                 mod = importlib.import_module(module)
                 obj = vars(mod).get(name, None)
-                if isinstance(obj, type) and issubclass(obj, KerasSaveable):
+                if obj is not None:
                     return obj
-                else:
-                    raise ValueError(
-                        f"Could not deserialize '{module}.{name}' because "
-                        "it is not a KerasSaveable subclass"
-                    )
             except ModuleNotFoundError:
                 raise TypeError(
                     f"Could not deserialize {obj_type} '{name}' because "

--- a/keras/src/trainers/data_adapters/__init__.py
+++ b/keras/src/trainers/data_adapters/__init__.py
@@ -28,20 +28,16 @@ def get_data_adapter(
     if isinstance(x, data_adapter.DataAdapter):
         return x
 
-    # Check for multi-process/worker distribution.
+    # Check for multi-process/worker distribution. Since only tf.dataset
+    # is supported at the moment, we will raise error if the inputs fail
+    # the type check
     distribution = distribution_lib.distribution()
-    if (
-        distribution is not None
-        and getattr(distribution, "_is_multi_process", False)
-        and getattr(distribution, "auto_shard_dataset", False)
-        and not is_tf_dataset(x)
+    if getattr(distribution, "_is_multi_process", False) and not is_tf_dataset(
+        x
     ):
         raise ValueError(
-            "When using a multi-worker distribution with auto-sharding enabled, "
-            "the data must be provided as a `tf.data.Dataset` instance. "
-            f"Received: type(x)={type(x)}. "
-            "If the dataset is already sharded across workers, then set "
-            "`distribution.auto_shard_dataset = False`."
+            "When using multi-worker distribution, the data must be provided "
+            f"as a `tf.data.Dataset` instance. Received: type(x)={type(x)}."
         )
 
     if array_data_adapter.can_convert_arrays((x, y, sample_weight)):
@@ -97,12 +93,7 @@ def get_data_adapter(
         if class_weight is not None:
             raise ValueError(
                 "Argument `class_weight` is not supported for torch "
-                f"DataLoader inputs. You can modify your `__getitem__ ` method"
-                " to return input tensor, label and class_weight. "
-                "Alternatively, use a custom training loop. See the User Guide "
-                "https://keras.io/guides/custom_train_step_in_torch/"
-                "#supporting-sampleweight-amp-classweight for more details. "
-                f"Received: class_weight={class_weight}"
+                f"DataLoader inputs. Received: class_weight={class_weight}"
             )
         return TorchDataLoaderAdapter(x)
         # TODO: should we warn or not?

--- a/requirements-common.txt
+++ b/requirements-common.txt
@@ -23,5 +23,4 @@ dm_tree
 coverage!=7.6.5  # 7.6.5 breaks CI
 # for onnx_test.py
 onnxruntime
-onnxscript  # Needed by TorchDynamo-based ONNX exporter
 openvino


### PR DESCRIPTION
Recreated from original PR: https://github.com/keras-team/keras/pull/21435

## Summary
This PR introduces support for `int4` weight-only quantization for the `Dense` layer. The implementation includes the necessary logic for packing and unpacking `int4` values, performing the quantized matrix multiplication, and ensuring compatibility with features like LoRA.

The code currently implements W4A8 quantization scheme.

## Description

The core changes include:

-   Support for `int4` quantization mode.

-   **Packing and Unpacking Utilities**:
    -   `pack_int...